### PR TITLE
Fix the getTabsCount function to accurately return the number of created tabs

### DIFF
--- a/lib/components/Tabs.js
+++ b/lib/components/Tabs.js
@@ -164,7 +164,7 @@ module.exports = _react2.default.createClass({
     return index;
   },
   getTabsCount: function getTabsCount() {
-    return this.props.children && this.props.children[0] ? _react2.default.Children.count(this.props.children[0].props.children) : 0;
+    return this.props.children[1] ? this.props.children[1].length : 0;
   },
   getPanelsCount: function getPanelsCount() {
     return _react2.default.Children.count(this.props.children.slice(1));


### PR DESCRIPTION
This fixes the issue in https://github.com/sqlectron/sqlectron-gui/issues/311

The way it's rendered in `sqlectron-gui` the 2nd child of the `Tabs` component is the array of `Tab` components, and the length of that array is the accurate count of the number of tabs created.

The way the code was before it was counting the number of children of the 0th child, which was just a div with 4 children, so as far as the Tabs component was concerned there were always 4 children.

Once we made a 5th, the component still thought there was only 4 so the `setSelected` function would always fail this check `if (index < 0 || index >= this.getTabsCount()) return;`

If you want to test this, just replace the react-tabs entry in the `package.json` of `sqlectron-gui` with `"react-tabs": "git+https://github.com/s-kem/react-tabs.git#remove-warnings",
`